### PR TITLE
Ensure DataFrames available in loader

### DIFF
--- a/src/datareader.jl
+++ b/src/datareader.jl
@@ -1,5 +1,6 @@
 using YAML
 using CSV
+using DataFrames
 
 function load_param_file(paramfile)
     


### PR DESCRIPTION
## Summary
- import `DataFrames` inside `datareader.jl` so CSV.read can return a `DataFrame`

## Testing
- `julia` command could not be run because Julia is not installed in the environment

------
https://chatgpt.com/codex/tasks/task_e_68402cc0523c832d9a1b6bd6883fb300